### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-from-export-zip.yml
+++ b/.github/workflows/release-from-export-zip.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   prep:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.meta.outputs.tag }}


### PR DESCRIPTION
Potential fix for [https://github.com/tajemniktv/TajsMod/security/code-scanning/1](https://github.com/tajemniktv/TajsMod/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the `prep` job that limits the `GITHUB_TOKEN` to the minimum necessary scope. The `prep` job only checks out the repository and reads files, so it only needs read access to repository contents. Therefore, we should set `contents: read` for this job.

Concretely, in `.github/workflows/release-from-export-zip.yml`, under `jobs:`, locate the `prep:` job (around line 11). Immediately under `prep:` (and at the same indentation level as `runs-on:`), insert:

```yaml
    permissions:
      contents: read
```

This preserves existing functionality while ensuring the `GITHUB_TOKEN` for this job cannot perform write operations. No additional imports, methods, or definitions are required, as this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
